### PR TITLE
Makefile: create service dir during init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ idris2 = idris2
 node = node
 
 init: FORCE
-	test -d db    || mkdir db
-	test -d build || mkdir build
+	test -d db      || mkdir db
+	test -d build   || mkdir build
+	test -d service || mkdir service
 	touch service/order-taking-service.js
 
 typecheck: src order-taking-service.ipkg FORCE


### PR DESCRIPTION
If service is not created before touch is called then the following
error occurs:

```
$ make start-opt
test -d db    || mkdir db
test -d build || mkdir build
touch service/order-taking-service.js
touch: cannot touch 'service/order-taking-service.js': No such file or directory
make: *** [init] Error 1
```

Creating the directory if required fixes the issue