### PR TITLE
Adds default package.json for client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ build/
 db/
 node_modules/
 package-lock.json
-package.json
+./package.json
 service/

--- a/client/svelte-client/package.json
+++ b/client/svelte-client/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "svelte-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "rollup -c",
+    "dev": "rollup -c -w",
+    "start": "sirv public --no-clear"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^17.0.0",
+    "@rollup/plugin-node-resolve": "^11.0.0",
+    "rollup": "^2.3.4",
+    "rollup-plugin-css-only": "^3.1.0",
+    "rollup-plugin-livereload": "^2.0.0",
+    "rollup-plugin-svelte": "^7.0.0",
+    "rollup-plugin-terser": "^7.0.0",
+    "svelte": "^3.0.0"
+  },
+  "dependencies": {
+    "sirv-cli": "^1.0.0"
+  }
+}


### PR DESCRIPTION
Without this `package.json` file the client cannot be built/started with
the `npm run dev` command.

The package.json comes from
https://github.com/sveltejs/component-template which is the same place
as other setup files for the client.

This file was missing because of the `package.json` entry in the
`.gitignore` file at the root of the repo. I've changed this to ignore
the `package.json` for the root project and to include the
`package.json` for the client.